### PR TITLE
Add the ability to specify a step's title as a context function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-...
+### Added
+
+- Add the ability to specify a test's `title` as a function of the context, in
+  addition to as a string.
 
 ## 0.1.0 - 2018-07-01
 

--- a/src/greenlight/step.clj
+++ b/src/greenlight/step.clj
@@ -12,7 +12,11 @@
 (s/def ::name symbol?)
 
 ;; Human friendly title string for the step.
-(s/def ::title string?)
+;; Can be supplied as a string or a function of the test context
+;; that returns a string.
+(s/def ::title
+  (s/or :str string?
+        :fn fn?))
 
 ;; Used for context lookups. Can be a keyword for direct access,
 ;; a collection of values for `get-in`, or a function of the context.
@@ -257,6 +261,13 @@
         :kws (assoc-in ctx output-key step-result)
         :fn (output-key ctx step-result)))
     ctx))
+
+
+(defn initialize
+  "Resolves contextual properties of a step prior to execution."
+  [step ctx]
+  (cond-> step
+    (fn? (::title step)) (update ::title #(% ctx))))
 
 
 (defn advance!

--- a/src/greenlight/test.clj
+++ b/src/greenlight/test.clj
@@ -111,7 +111,8 @@
          steps steps]
     (if-let [step (first steps)]
       ; Run next step to advance the test.
-      (let [_ (*report* {:type :step-start
+      (let [step (step/initialize step ctx)
+            _ (*report* {:type :step-start
                          :step step})
             [step' ctx'] (step/advance! system step ctx)
             history' (conj history step')]

--- a/test/greenlight/test_test.clj
+++ b/test/greenlight/test_test.clj
@@ -46,7 +46,8 @@
                    :e (* 2 b)
                    :f (* 2 c)})}
   [#::step{:name 'third-step
-           :title "Third Step"
+           :title (fn [{:keys [d e f]}]
+                    (format "d: %s, e: %s, f: %s" d e f))
            :inputs {:x (step/lookup :d)
                     :y (step/lookup :e)
                     :z (step/lookup :f)}
@@ -59,5 +60,10 @@
 (deftest sample-test
   (let [system (component/system-map ::component 6)
         test-result (test/run-test! system (sample-greenlight-test))]
+    (is (= ["Sample Step"
+            "Sample Step"
+            "Another Step"
+            "d: 8, e: 10, f: 12"]
+           (mapv ::step/title (::test/steps test-result))))
     (is (= :pass (::test/outcome test-result)))
     (is (= 4 (count (::test/steps test-result))))))


### PR DESCRIPTION
In order to be able to specify a test title as suggested in #16 

```clojure
{::step/name 'make-foo-in-bar
 ::step/title (fn [ctx] (format "Making foo in bar %s" (:bar/id ctx)))
 ,,,}
```