### PR TITLE
Make docstring and title optional on `defstep`

### DIFF
--- a/src/greenlight/step.clj
+++ b/src/greenlight/step.clj
@@ -96,15 +96,15 @@
     {:foo/name \"Foo 1\"}
     :output :foo.1/id)"
   [step-name & step-decl]
-  (let [docstring (if (string? (first step-decl)) (first step-decl) "")
-        default-config (-> (if (string? (first step-decl))
-                             (rest step-decl)
-                             step-decl)
+  (let [docstring (when (string? (first step-decl)) (first step-decl))
+        fn-declaration (if docstring
+                         `(defn ~step-name ~docstring)
+                         `(defn ~step-name))
+        default-config (-> (if docstring (rest step-decl) step-decl)
                            (->> (apply hash-map))
                            (update :title #(or % (str *ns* \/ step-name)))
                            qualify-config-keys)]
-    `(defn ~step-name
-       ~docstring
+    `(~@fn-declaration
        ([]
         (~step-name {}))
        ([~'inputs & {:as ~'config}]

--- a/src/greenlight/step.clj
+++ b/src/greenlight/step.clj
@@ -102,8 +102,8 @@
                          `(defn ~step-name))
         default-config (-> (if docstring (rest step-decl) step-decl)
                            (->> (apply hash-map))
-                           (update :title #(or % (str *ns* \/ step-name)))
-                           qualify-config-keys)]
+                           qualify-config-keys
+                           (update ::title #(or % (str *ns* \/ step-name))))]
     `(~@fn-declaration
        ([]
         (~step-name {}))

--- a/src/greenlight/step.clj
+++ b/src/greenlight/step.clj
@@ -95,12 +95,14 @@
   (create-foo
     {:foo/name \"Foo 1\"}
     :output :foo.1/id)"
-  [step-name docstring & default-config]
-  (when-not (string? docstring)
-    (throw (IllegalArgumentException.
-             "defstep expects a docstring for the step constructor")))
-  (let [default-config (qualify-config-keys
-                         (apply hash-map default-config))]
+  [step-name & step-decl]
+  (let [docstring (if (string? (first step-decl)) (first step-decl) "")
+        default-config (-> (if (string? (first step-decl))
+                             (rest step-decl)
+                             step-decl)
+                           (->> (apply hash-map))
+                           (update :title #(or % (str *ns* \/ step-name)))
+                           qualify-config-keys)]
     `(defn ~step-name
        ~docstring
        ([]

--- a/test/greenlight/test_suite/blue.clj
+++ b/test/greenlight/test_suite/blue.clj
@@ -19,6 +19,17 @@
           (is (= 3 baz))
           4))
 
+(defstep sample-step-without-optionals
+  :inputs {:foo 1
+           :bar 2
+           :baz -1}
+  ::step/output [::foo ::bar ::baz]
+  :test (fn [{:keys [foo bar baz]}]
+          (is (= 1 foo))
+          (is (= 2 bar))
+          (is (= 3 baz))
+          4))
+
 
 (deftest sample-test
   "A sample greenlight test in the blue test suite"
@@ -27,6 +38,8 @@
   (sample-step
     {:baz 3}
     :output [::foo ::bar ::baz2])
+  (sample-step-without-optionals
+    {:baz 3})
   #::step{:name 'another-step
           :title "Another Step"
           :output (fn [ctx outputs]

--- a/test/greenlight/test_test.clj
+++ b/test/greenlight/test_test.clj
@@ -13,7 +13,8 @@
     (is (= :pass (::test/outcome test-result)))
     (is (= ["Sample Step"
             "Sample Step"
+            "greenlight.test-suite.blue/sample-step-without-optionals"
             "Another Step"
             "d: 8, e: 10, f: 12"]
            (mapv ::step/title (::test/steps test-result))))
-    (is (= 4 (count (::test/steps test-result))))))
+    (is (= 5 (count (::test/steps test-result))))))


### PR DESCRIPTION
Sometimes the step name is already descriptive enough.