### PR TITLE
Make assertion outcomes extensible

### DIFF
--- a/src/greenlight/assert.clj
+++ b/src/greenlight/assert.clj
@@ -1,0 +1,8 @@
+(ns greenlight.assert)
+
+(defmulti report->outcome :type)
+
+(defmethod report->outcome :pass [_] ::pass)
+(defmethod report->outcome :fail [_] ::fail)
+(defmethod report->outcome :error [_] ::error)
+(defmethod report->outcome :default [_] ::pass)

--- a/src/greenlight/step.clj
+++ b/src/greenlight/step.clj
@@ -3,7 +3,8 @@
   (:require
     [clojure.spec.alpha :as s]
     [clojure.string :as str]
-    [clojure.test :as ctest]))
+    [clojure.test :as ctest]
+    [greenlight.assert :as assert]))
 
 
 ;; ## Step Configuration
@@ -272,15 +273,6 @@
     (fn? (::title step)) (update ::title #(% ctx))))
 
 
-(defmulti report->outcome :type)
-
-(defmethod report->outcome :pass [_] :greenlight.assert/pass)
-(defmethod report->outcome :fail [_] :greenlight.assert/fail)
-(defmethod report->outcome :error [_] :greenlight.assert/error)
-(defmethod report->outcome :matcher-combinators/mismatch [_] :greenlight.assert/fail)
-(defmethod report->outcome :default [_] :greenlight.assert/pass)
-
-
 (defn advance!
   "Advance the test by performing the next step. Returns a tuple of the
   enriched step map and updated context."
@@ -309,9 +301,9 @@
                  :timeout
                  (format "Step timed out after %d seconds" timeout))
                ctx])
-            (let [report-types (group-by report->outcome @reports)
-                  passed? (and (empty? (:greenlight.assert/fail report-types))
-                               (empty? (:greenlight.assert/error report-types)))]
+            (let [report-types (group-by assert/report->outcome @reports)
+                  passed? (and (empty? (::assert/fail report-types))
+                               (empty? (::assert/error report-types)))]
               [(output-step
                  (if passed? :pass :fail)
                  (->> report-types

--- a/src/greenlight/step.clj
+++ b/src/greenlight/step.clj
@@ -309,7 +309,7 @@
                  :timeout
                  (format "Step timed out after %d seconds" timeout))
                ctx])
-            (let [report-types (group-by (comp report->outcome :type) @reports)
+            (let [report-types (group-by report->outcome @reports)
                   passed? (and (empty? (:greenlight.assert/fail report-types))
                                (empty? (:greenlight.assert/error report-types)))]
               [(output-step

--- a/test/greenlight/test_test.clj
+++ b/test/greenlight/test_test.clj
@@ -17,4 +17,16 @@
             "Another Step"
             "d: 8, e: 10, f: 12"]
            (mapv ::step/title (::test/steps test-result))))
+    (is (= 5 (count (::test/steps test-result)))))
+
+  (let [system      (component/system-map :greenlight.test-test/component 5)
+        sample-test (blue/sample-test)
+        test-result (test/run-test! system sample-test)]
+    (is (= :fail (::test/outcome test-result)))
+    (is (= ["Sample Step"
+            "Sample Step"
+            "greenlight.test-suite.blue/sample-step-without-optionals"
+            "Another Step"]
+           (butlast
+            (mapv ::step/title (::test/steps test-result)))))
     (is (= 5 (count (::test/steps test-result))))))


### PR DESCRIPTION
Today it only supports `clojure.test` assertions by checking `:pass`, `:fail`, and `:error`. Adding a multimethod that should return the outcome is an easy way to make this behavior extendable. One example already included with this code is [nubank/matcher-combinators](/nubank/matcher-combinators)' `mismatch` type.