### PR TITLE
Multithreaded test execution/test groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ to match test name.
 
 ### Parallel Test Execution
 
-Tests can be executed in parallel by providing a `--multithread` option
+Tests can be executed in parallel by providing a `--parallel` option
 with a number of threads. Tests can be further grouped with `::test/group`
 metadata to indicate that tests within the same group should run serially.
 
@@ -357,7 +357,7 @@ Groups of tests are run in parallel.
   [(simple1)
    (simple2)
    (simple3)]
-  {:multithread 2})
+  {:parallel 2})
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ a suite of tests against your systems gives you the confidence to _greenlight_
 them for promotion to production. The primary goals of this framework are:
 
 - Steps should be _composable_ to drive down repetition in similar tests.
-- Tests should be _distributable_ and support parallelization out-of-the-box.
+- Tests should support parallelization out-of-the-box.
 - Results should be _actionable_ and easy to understand.
 
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ a suite of tests against your systems gives you the confidence to _greenlight_
 them for promotion to production. The primary goals of this framework are:
 
 - Steps should be _composable_ to drive down repetition in similar tests.
-- TODO: Tests should be _distributable_ and support parallelization out-of-the-box.
+- Tests should be _distributable_ and support parallelization out-of-the-box.
 - Results should be _actionable_ and easy to understand.
 
 
@@ -326,6 +326,38 @@ to match test name.
 
 (runner/find-tests #"test-2")
 => (#:greenlight.test{:description ",,,", :title "test-2", :ns user, :line 5, :steps []})
+```
+
+### Parallel Test Execution
+
+Tests can be executed in parallel by providing a `--multithread` option
+with a number of threads. Tests can be further grouped with `::test/group`
+metadata to indicate that tests within the same group should run serially.
+
+If a `::test/group` is not provided, a test is placed in its own group.
+Groups of tests are run in parallel.
+
+
+```clojure
+(deftest simple1
+  (math-test))
+
+(deftest simple2
+  {::test/group :sync}
+  (math-test))
+
+(deftest simple3
+  {::test/group :sync}
+  (math-test))
+
+;; Will run `simple1` and `simple2` concurrently, then
+;; `simple3` on completion of `simple2`.
+(runner/run-tests!
+  (constantly {})
+  [(simple1)
+   (simple2)
+   (simple3)]
+  {:multithread 2})
 ```
 
 ## License

--- a/src/greenlight/runner.clj
+++ b/src/greenlight/runner.clj
@@ -139,7 +139,6 @@
   [system tests n-threads]
   (let [exec-pool (Executors/newFixedThreadPool n-threads)
         printer (sync-printer)
-        bindings (get-thread-bindings)
         run-group (fn run-group
                     [tests]
                     (bound-fn []

--- a/src/greenlight/runner.clj
+++ b/src/greenlight/runner.clj
@@ -113,15 +113,12 @@
 (defmacro ^:private with-delayed-output
   [printer & body]
   `(let [out# (java.io.StringWriter.)
-         original-out# *out*
-         original-err# *err*
-         printer# ~printer]
-     (binding [*out* out#, *err* out#]
-       (let [result# (do ~@body)]
-         (binding [*out* original-out#
-                   *err* original-err#]
-           (printer# (str out#))
-           result#)))))
+         printer# ~printer
+         result# (binding [*out* out#
+                           *err* out#]
+                   ~@body)]
+     (printer# (str out#))
+     result#))
 
 
 (defn- sync-printer

--- a/src/greenlight/runner.clj
+++ b/src/greenlight/runner.clj
@@ -105,12 +105,13 @@
   [printer & body]
   `(let [out# (java.io.StringWriter.)
          original-out# *out*
-         original-err# *err*]
+         original-err# *err*
+         printer# ~printer]
      (binding [*out* out#, *err* out#]
-       (let [result# ~@body]
+       (let [result# (do ~@body)]
          (binding [*out* original-out#
                    *err* original-err#]
-           (~printer (str out#))
+           (printer# (str out#))
            result#)))))
 
 

--- a/src/greenlight/runner.clj
+++ b/src/greenlight/runner.clj
@@ -19,7 +19,7 @@
    [nil  "--no-color" "Disable the use of color in console output."]
    [nil  "--html-report FILE" "Report test results as HTML to the given path."]
    [nil  "--junit-report FILE" "Report test results as Junit XML to the given path."]
-   [nil  "--multithread N" "Run tests with multiple threads."
+   [nil  "--parallel N" "Run tests with the provided parallelization factor."
     :parse-fn #(Integer/parseInt %)]
    ["-h" "--help"]])
 
@@ -150,7 +150,7 @@
          (binding [test/*report* (partial report/handle-test-event
                                           {:print-color (not (:no-color options))})]
            (println "Running" (count tests) "tests...")
-           (let [results (if-let [n-threads (:multithread options)]
+           (let [results (if-let [n-threads (:parallel options)]
                            (execute-parallel system tests n-threads)
                            (mapv (partial test/run-test! system) tests))]
              ;; TODO: check result spec?

--- a/src/greenlight/runner.clj
+++ b/src/greenlight/runner.clj
@@ -11,8 +11,7 @@
     [greenlight.test :as test])
   (:import
     (java.util.concurrent
-      Executors
-      ExecutorService)))
+      Executors)))
 
 
 (def cli-options

--- a/src/greenlight/runner.clj
+++ b/src/greenlight/runner.clj
@@ -20,8 +20,7 @@
    [nil  "--no-color" "Disable the use of color in console output."]
    [nil  "--html-report FILE" "Report test results as HTML to the given path."]
    [nil  "--junit-report FILE" "Report test results as Junit XML to the given path."]
-   [nil  "--multithread THREADS" "Run tests with multiple threads."
-    :default (* 2 (.availableProcessors (Runtime/getRuntime)))
+   [nil  "--multithread N" "Run tests with multiple threads."
     :parse-fn #(Integer/parseInt %)]
    ["-h" "--help"]])
 

--- a/src/greenlight/runner.clj
+++ b/src/greenlight/runner.clj
@@ -81,7 +81,7 @@
     true))
 
 
-(defmacro with-delayed-output
+(defmacro ^:private with-delayed-output
   [printer & body]
   `(let [out# (java.io.StringWriter.)
          original-out# *out*
@@ -95,6 +95,7 @@
 
 
 (defn- sync-printer
+  "Creates a synchronized printer function"
   []
   (let [o (Object.)]
     (fn [s]
@@ -104,6 +105,7 @@
 
 
 (defn- execute-parallel
+  "Run a collection of tests, using an executor pool with `n-threads`"
   [system tests n-threads]
   (let [exec-pool (Executors/newFixedThreadPool n-threads)
         printer (sync-printer)

--- a/src/greenlight/test.clj
+++ b/src/greenlight/test.clj
@@ -23,6 +23,10 @@
 ;; Human-friendly description of the scenario the test covers.
 (s/def ::description string?)
 
+;; Test execution group tag. Tests within the same group
+;; are executed in serial.
+(s/def ::group keyword?)
+
 ;; Sequence of steps to take for this test.
 (s/def ::steps
   (s/coll-of ::step/config

--- a/test/greenlight/runner_test.clj
+++ b/test/greenlight/runner_test.clj
@@ -2,6 +2,7 @@
   (:require
     [clojure.test :refer :all]
     [greenlight.runner :as runner]
+    [greenlight.test :as test]
     [greenlight.test-suite.blue :as blue]
     [greenlight.test-suite.red :as red]))
 
@@ -31,3 +32,38 @@
       ['greenlight.test-suite.red] (mapv :greenlight.test/ns red-test-only)
       ['greenlight.test-suite.blue/sample-test] (mapv test-name one-blue-test-only)
       ['greenlight.test-suite.blue/sample-test] (mapv test-name one-blue-test-only-re))))
+
+
+(test/deftest ^:a test-a "a")
+(test/deftest ^:b test-b "b")
+(test/deftest ^:c test-c
+  {::test/group :group/c
+   ::test/description "c"})
+
+
+(deftest finding-tests
+  (let [test-vars [#'test-a #'test-b #'test-c]]
+    (are [matcher tests] (= tests (#'runner/filter-tests matcher test-vars))
+      ;; Return all with no matcher
+      nil [(test-a) (test-b) (test-c)]
+
+      ;; Match on metadata
+      :a [(test-a)]
+      :b [(test-b)]
+
+      ;; Regular expression on test name
+      #"test-a" [(test-a)]
+      #"test-." [(test-a) (test-b) (test-c)]
+
+      ;; By test properties
+      {::test/ns 'greenlight.runner-test}
+      [(test-a) (test-b) (test-c)]
+
+      {::test/ns 'greenlight.runner-test, ::test/title "test-a"}
+      [(test-a)]
+
+      {::test/group :group/c}
+      [(test-c)]
+
+      {::test/group :group/c ::test/ns 'foo.bar}
+      [])))

--- a/test/greenlight/runner_test.clj
+++ b/test/greenlight/runner_test.clj
@@ -1,9 +1,11 @@
 (ns greenlight.runner-test
   (:require
     [clojure.test :refer :all]
-    [greenlight.test-suite.red :as red]
+    [greenlight.runner :as runner]
+    [greenlight.test :as test]
     [greenlight.test-suite.blue :as blue]
-    [greenlight.runner :as runner]))
+    [greenlight.test-suite.red :as red]))
+
 
 (deftest filter-test-suite
   (let [tests [(blue/sample-test) (red/sample-test)]
@@ -14,3 +16,39 @@
       ['greenlight.test-suite.blue 'greenlight.test-suite.red] (mapv :greenlight.test/ns all-tests)
       ['greenlight.test-suite.blue] (mapv :greenlight.test/ns blue-test-only)
       ['greenlight.test-suite.red] (mapv :greenlight.test/ns red-test-only))))
+
+
+
+(test/deftest ^:a test-a "a")
+(test/deftest ^:b test-b "b")
+(test/deftest ^:c test-c
+  {::test/group :group/c
+   ::test/description "c"})
+
+
+(deftest finding-tests
+  (let [test-vars [#'test-a #'test-b #'test-c]]
+    (are [matcher tests] (= tests (#'runner/filter-tests matcher test-vars))
+      ;; Return all with no matcher
+      nil [(test-a) (test-b) (test-c)]
+
+      ;; Match on metadata
+      :a [(test-a)]
+      :b [(test-b)]
+
+      ;; Regular expression on test name
+      #"test-a" [(test-a)]
+      #"test-." [(test-a) (test-b) (test-c)]
+
+      ;; By test properties
+      {::test/ns 'greenlight.runner-test}
+      [(test-a) (test-b) (test-c)]
+
+      {::test/ns 'greenlight.runner-test, ::test/title "test-a"}
+      [(test-a)]
+
+      {::test/group :group/c}
+      [(test-c)]
+
+      {::test/group :group/c ::test/ns 'foo.bar}
+      [])))


### PR DESCRIPTION
## Description

Provides a new option `:multithread` to run tests in parallel to address #22. By default, tests are run serially as they are today.

To ensure that tests that cannot be run concurrently don't overlap, this also allows tests to be grouped for execution using a `::test/group` metadata keyword. Tests that are in the same test group are executed in serial, with all test groups executing concurrently.

When executing tests in parallel all test output is buffered and then printed at the end of test execution to avoid interleaved messaging.