### PR TITLE
Allow optional deduplication of cleanups

### DIFF
--- a/src/greenlight/step.clj
+++ b/src/greenlight/step.clj
@@ -185,7 +185,12 @@
 
 
 (defn register-cleanup!
-  "Registers a cleanup job with the `*pending-cleanups*` atom, if bound."
+  "Registers a cleanup job with the `*pending-cleanups*` atom, if bound.
+
+  Allows an optional param map with the following:
+  - :unique?
+    Specifies whether the registered cleanup should be deduplicated against
+    already registered cleanups"
   ([resource-type parameters]
    (register-cleanup! resource-type parameters {}))
   ([resource-type parameters {:keys [unique?]}]

--- a/test/greenlight/step_test.clj
+++ b/test/greenlight/step_test.clj
@@ -1,0 +1,27 @@
+(ns greenlight.step-test
+  (:require
+    [clojure.test :refer [is testing deftest]]
+    [greenlight.step :as sut]))
+
+(deftest register-cleanup!
+  (testing "Default use case"
+    (binding [sut/*pending-cleanups* (sut/new-cleanups)]
+      (sut/register-cleanup! :hax/dirty {:custom "param"})
+      (sut/register-cleanup! :some/other nil)
+      (sut/register-cleanup! :hax/dirty {:custom "param"})
+      (sut/register-cleanup! :last/one {})
+      (is (= [[:hax/dirty {:custom "param"}]
+              [:some/other nil]
+              [:hax/dirty {:custom "param"}]
+              [:last/one {}]]
+             @sut/*pending-cleanups*))))
+  (testing "Don't add duplicate cleanups"
+    (binding [sut/*pending-cleanups* (sut/new-cleanups)]
+      (sut/register-cleanup! :hax/dirty {:custom "param"})
+      (sut/register-cleanup! :some/other nil)
+      (sut/register-cleanup! :hax/dirty {:custom "param"} {:unique? true})
+      (sut/register-cleanup! :some/other nil)
+      (is (= [[:hax/dirty {:custom "param"}]
+              [:some/other nil]
+              [:some/other nil]]
+             @sut/*pending-cleanups*)))))


### PR DESCRIPTION
This is a small patch to add a new param map to `step/register-cleanup!` that allows the caller to specify that the cleanup should only be run once.  

I ran into needing this when cleaning up index data that was shared across multiple runs of a job -- each run would register a cleanup, but the second cleanup to run would hit an exception as the resource was already cleaned up by the first registered cleanup.