### PR TITLE
Bind clojure test out for output failure alignment

### DIFF
--- a/src/greenlight/runner.clj
+++ b/src/greenlight/runner.clj
@@ -5,6 +5,7 @@
     [clojure.set :as set]
     [clojure.spec.alpha :as s]
     [clojure.string :as str]
+    [clojure.test :as ctest]
     [clojure.tools.cli :as cli]
     [com.stuartsierra.component :as component]
     [greenlight.report :as report]
@@ -115,7 +116,8 @@
   `(let [out# (java.io.StringWriter.)
          printer# ~printer
          result# (binding [*out* out#
-                           *err* out#]
+                           *err* out#
+                           ctest/*test-out* out#]
                    ~@body)]
      (printer# (str out#))
      result#))


### PR DESCRIPTION
I noticed the clojure test assertion output was sometimes far away from the reported test failure in parallel tests. `clojure.test` has a `*test-out*` var that is bound to `*out*` by default, this additionally binds that to our `StringWriter` for output.