### PR TITLE
Report timeouts as errors in JUnit reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- JUnit test output now reports `:timeout`s as errors.
+
 ## 0.1.7 - 2019-05-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 0.2.0 - 2020-03-25
+
 ### Fixed
 
 - JUnit test output now reports `:timeout`s as errors.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject amperity/greenlight "0.2.0-SNAPSHOT"
+(defproject amperity/greenlight "0.2.0"
   :description "Clojure integration testing framework."
   :url "https://github.com/amperity/greenlight"
   :license {:name "Apache License 2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject amperity/greenlight "0.1.7"
+(defproject amperity/greenlight "0.2.0-SNAPSHOT"
   :description "Clojure integration testing framework."
   :url "https://github.com/amperity/greenlight"
   :license {:name "Apache License 2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject amperity/greenlight "0.2.0"
+(defproject amperity/greenlight "0.2.1-SNAPSHOT"
   :description "Clojure integration testing framework."
   :url "https://github.com/amperity/greenlight"
   :license {:name "Apache License 2.0"

--- a/src/greenlight/report/junit.clj
+++ b/src/greenlight/report/junit.clj
@@ -17,7 +17,7 @@
                          {:time (format "%.3f" elapsed)}))]
     (not outcome)
       (conj [:skipped])
-    (= :error outcome) ;; TODO: timeout?
+    (or (= :error outcome) (= :timeout outcome))
       (conj [:error {:message message}])
     (= :failure outcome)
       (conj [:failure {:message message}])))
@@ -33,7 +33,7 @@
         :timestamp (str started-at)
         :tests (count steps)
         :time (format "%.3f" (/ duration 1e9))
-        :errors (:error outcomes 0) ;; TODO: timeout?
+        :errors (+ (:error outcomes 0) (:timeout outcomes 0))
         :failures (:fail outcomes 0)
         :skipped (get outcomes nil 0)})]
     (map (partial step->testcase ns))


### PR DESCRIPTION
Greenlight has a concept of timeouts separate from errors or failures. JUnit has no such distinction, and we weren't reporting timeouts at all before, so if you only looked at the JUnit reports, it would look like the tests passed when they didn't (if they had timeouts but not errors or failures).

This includes timeouts as errors in the JUnit reporting.

This also includes a `0.2.0` release, and a version bump to `0.2.1-SNAPSHOT`.