### PR TITLE
Exclude org.clojure/clojure in lein-codox plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Update dependencies to latest versions.
+- Exclude `clojure` from `lein-codox` dependencies so that it will actually
+  build.
 
 ## 0.2.0 - 2020-03-25
 

--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,7 @@
    :output-path "target/doc/codox"}
 
   :plugins
-  [[lein-codox "0.10.7"]
+  [[lein-codox "0.10.7" :exclusions [org.clojure/clojure]]
    [lein-cloverage "1.1.2"]]
 
   :profiles


### PR DESCRIPTION
We use the `:pedantic :abort` project setting, but this requires that
none of your dependencies or plugins load different dependency versions
themselves.

`lein-codox` depends on an ancient version of Clojure, so we should
exclude Clojure from its dependency chain to not gum up the works.

This PR depends on #43, please review that first.