### PR TITLE
Fix another JUnit reporting bug and add test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Exclude `clojure` from `lein-codox` dependencies so that it will actually
   build.
 
+### Fixed
+
+- JUnit test output now properly adds `<failure>` child objects of `<testcase>`
+  objects.
+
 ## 0.2.0 - 2020-03-25
 
 ### Fixed

--- a/src/greenlight/report/junit.clj
+++ b/src/greenlight/report/junit.clj
@@ -19,7 +19,7 @@
       (conj [:skipped])
     (or (= :error outcome) (= :timeout outcome))
       (conj [:error {:message message}])
-    (= :failure outcome)
+    (= :fail outcome)
       (conj [:failure {:message message}])))
 
 

--- a/test/greenlight/report/junit_test.clj
+++ b/test/greenlight/report/junit_test.clj
@@ -1,0 +1,88 @@
+(ns greenlight.report.junit-test
+  "Tests for JUnit report generation."
+  (:require
+    [clojure.test :refer [deftest is testing]]
+    [greenlight.report.junit :as junit])
+  (:import
+    java.time.Instant))
+
+
+(def ^:private greenlight-edn
+  [{:greenlight.test/ns 'foo-test-ns
+    :greenlight.test/title "foo-test-title"
+    :greenlight.test/outcome :pass
+    :greenlight.test/started-at (Instant/parse "2007-12-03T10:15:30.00Z")
+    :greenlight.test/ended-at (Instant/parse "2007-12-03T10:15:31.00Z")
+    :greenlight.test/steps
+    [{:greenlight.step/title "foo-test-step-title"
+      :greenlight.step/outcome :pass
+      :greenlight.step/elapsed 1.0
+      :greenlight.step/message "foo-test-step message"
+      :greenlight.step/name 'foo-test-step}]}
+   {:greenlight.test/ns 'foo-fail-ns
+    :greenlight.test/title "foo-fail-title"
+    :greenlight.test/outcome :fail
+    :greenlight.test/started-at (Instant/parse "2007-12-03T10:15:30.00Z")
+    :greenlight.test/ended-at (Instant/parse "2007-12-03T10:15:31.00Z")
+    :greenlight.test/steps
+    [{:greenlight.step/title "foo-fail-step-title"
+      :greenlight.step/outcome :fail
+      :greenlight.step/elapsed 1.0
+      :greenlight.step/message "foo-fail-step message"
+      :greenlight.step/name 'foo-fail-step}]}
+   {:greenlight.test/ns 'foo-error-ns
+    :greenlight.test/title "foo-error-title"
+    :greenlight.test/outcome :error
+    :greenlight.test/started-at (Instant/parse "2007-12-03T10:15:30.00Z")
+    :greenlight.test/ended-at (Instant/parse "2007-12-03T10:15:31.00Z")
+    :greenlight.test/steps
+    [{:greenlight.step/title "foo-error-step-title"
+      :greenlight.step/outcome :error
+      :greenlight.step/elapsed 1.0
+      :greenlight.step/message "foo-error-step message"
+      :greenlight.step/name 'foo-error-step}]}])
+(def ^:private junit-edn
+  [:testsuites
+   [:testsuite
+    {:name "foo-test-title"
+     :timestamp "2007-12-03T10:15:30Z"
+     :tests 1
+     :time "1.000"
+     :errors 0
+     :failures 0
+     :skipped 0}
+    [:testcase
+     {:name "foo-test-step-title"
+      :classname 'foo-test-ns
+      :time "1.000"}]]
+   [:testsuite
+    {:name "foo-fail-title"
+     :timestamp "2007-12-03T10:15:30Z"
+     :tests 1
+     :time "1.000"
+     :errors 0
+     :failures 1
+     :skipped 0}
+    [:testcase
+     {:name "foo-fail-step-title"
+      :classname 'foo-fail-ns
+      :time "1.000"}
+     [:failure {:message "foo-fail-step message"}]]]
+   [:testsuite
+    {:name "foo-error-title"
+     :timestamp "2007-12-03T10:15:30Z"
+     :tests 1
+     :time "1.000"
+     :errors 1
+     :failures 0
+     :skipped 0}
+    [:testcase
+     {:name "foo-error-step-title"
+      :classname 'foo-error-ns
+      :time "1.000"}
+     [:error {:message "foo-error-step message"}]]]])
+
+
+(deftest happy-case
+  (testing "junit results transformation"
+    (is (= junit-edn (#'junit/results->testsuites greenlight-edn)))))

--- a/test/greenlight/report/junit_test.clj
+++ b/test/greenlight/report/junit_test.clj
@@ -41,6 +41,8 @@
       :greenlight.step/elapsed 1.0
       :greenlight.step/message "foo-error-step message"
       :greenlight.step/name 'foo-error-step}]}])
+
+
 (def ^:private junit-edn
   [:testsuites
    [:testsuite


### PR DESCRIPTION
Previously, we weren't correctly adding `<failure>` child objects to
`<testcase>` objects, which was breaking test reporting in some places.
(However, the counts on the `<testsuite>` objects were correct.)

This also adds a test for the non-XML-writing part of the JUnit
reporting library.