### PR TITLE
Prompt to retry steps if :on-fail :prompt option given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
 - Prompt for retries if a step fails.
 
 ## 0.3.0 - 2020-04-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Prompt for retries if a step fails.
+
 ## 0.3.0 - 2020-04-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ use the `ManagedSystem` protocol provider in the runner namespace, which support
   java.util.Map
   (start-system [this] (integrant/init this))
   (stop-system [this] (integrant/halt! this)))
-  
+
 (runner/run-tests! (constantly {:some-system-map :with-components})
                    tests {})
 
@@ -174,7 +174,7 @@ use the `ManagedSystem` protocol provider in the runner namespace, which support
 (runner/run-tests! (constantly
                      (with-meta {:some-system-map :with-components}
                        {`runner/start-system (fn [this] (println "Starting test system...") this)
-                        `runner/stop-system (fn [this] (println "Stopping test system...") nil)})) 
+                        `runner/stop-system (fn [this] (println "Stopping test system...") nil)}))
                    tests {})
 ```
 
@@ -380,6 +380,24 @@ Groups of tests are run in parallel.
    (simple3)]
   {:parallel 2})
 ```
+
+## Retrying steps
+
+Integration tests can sometimes be slow, or reliant on less stable systems. When
+running such tests manually, it can be helpful to not have to rerun entire tests
+from the beginning. You can do this by passing `{:on-fail :prompt}` to the test
+runner:
+
+```
+(runner/run-tests!
+  (constantly {})
+  [(simple1)
+   (simple2)
+   (simple3)]
+  {:on-fail :prompt})
+```
+
+When a step fails, it will now ask if you want to retry the step.
 
 ## License
 

--- a/src/greenlight/runner.clj
+++ b/src/greenlight/runner.clj
@@ -157,7 +157,7 @@
 
 (defn- execute-parallel
   "Run a collection of tests, using an executor pool with `n-threads`"
-  [system tests n-threads]
+  [system options tests n-threads]
   (let [exec-pool (Executors/newFixedThreadPool n-threads)
         printer (sync-printer)
         run-group (fn run-group
@@ -167,7 +167,7 @@
                         (fn [test]
                           (printer (str "* " (::test/title test) " running.\n"))
                           (with-delayed-output printer
-                            (test/run-test! system test)))
+                            (test/run-test! system options test)))
                         tests)))
         test-groups (group-by #(or (::test/group %) (gensym)) tests)]
     (try
@@ -206,8 +206,8 @@
            (println "Running" (count tests) "tests...")
            (let [results (let [parallelization (:parallel options 1)]
                            (if (< 1 parallelization)
-                             (execute-parallel system tests parallelization)
-                             (mapv (partial test/run-test! system) tests)))]
+                             (execute-parallel system options tests parallelization)
+                             (mapv (partial test/run-test! system options) tests)))]
              ;; TODO: check result spec?
              (newline)
              (report-results results options)

--- a/src/greenlight/test.clj
+++ b/src/greenlight/test.clj
@@ -3,6 +3,7 @@
   specific usage scenario."
   (:require
     [clojure.spec.alpha :as s]
+    [clojure.string :as str]
     [greenlight.step :as step])
   (:import
     java.time.Instant
@@ -132,10 +133,10 @@
   (loop []
     (print (str "Retry? [y/n] "))
     (flush)
-    (case (str/lower-case (str/trim (read-line)))]
+    (case (str/lower-case (str/trim (read-line)))
       ("y" "yes") true
       ("n" "no") false
-      (recur))
+      (recur))))
 
 
 (defn- retry-step?

--- a/src/greenlight/test.clj
+++ b/src/greenlight/test.clj
@@ -196,20 +196,22 @@
 
 (defn run-test!
   "Execute a test. Returns the updated test map."
-  [system options test-case]
-  (*report* {:type :test-start
-             :test test-case})
-  (let [started-at (Instant/now)
-        ctx (::context test-case {})
-        [history ctx] (run-steps! system options ctx (::steps test-case))
-        _ (run-cleanup! system history)
-        ended-at (Instant/now)
-        test-case (assoc test-case
-                         ::steps history
-                         ::context ctx
-                         ::outcome (last (keep ::step/outcome history))
-                         ::started-at started-at
-                         ::ended-at ended-at)]
-    (*report* {:type :test-end
-               :test test-case})
-    test-case))
+  ([system test-case]
+   (run-test! system {} test-case))
+  ([system options test-case]
+   (*report* {:type :test-start
+              :test test-case})
+   (let [started-at (Instant/now)
+         ctx (::context test-case {})
+         [history ctx] (run-steps! system options ctx (::steps test-case))
+         _ (run-cleanup! system history)
+         ended-at (Instant/now)
+         test-case (assoc test-case
+                          ::steps history
+                          ::context ctx
+                          ::outcome (last (keep ::step/outcome history))
+                          ::started-at started-at
+                          ::ended-at ended-at)]
+     (*report* {:type :test-end
+                :test test-case})
+     test-case)))

--- a/src/greenlight/test.clj
+++ b/src/greenlight/test.clj
@@ -132,11 +132,10 @@
   (loop []
     (print (str "Retry? [y/n] "))
     (flush)
-    (let [response (read-line)]
-      (cond
-        (re-find #"(?i)^\s*y(?:es)?\s*$" response) true
-        (re-find #"(?i)^\s*no?\s*$" response) false
-        :else (recur)))))
+    (case (str/lower-case (str/trim (read-line)))]
+      ("y" "yes") true
+      ("n" "no") false
+      (recur))
 
 
 (defn- retry-step?

--- a/src/greenlight/test.clj
+++ b/src/greenlight/test.clj
@@ -126,12 +126,33 @@
   nil)
 
 
+(defn- prompt-for-retry
+  "Enter a retry prompt loop. Return true if retry selected, false otherwise."
+  []
+  (loop []
+    (print (str "Retry? [y/n] "))
+    (flush)
+    (let [response (read-line)]
+      (cond
+        (re-find #"(?i)^\s*y(?:es)?\s*$" response) true
+        (re-find #"(?i)^\s*no?\s*$" response) false
+        :else (recur)))))
+
+
+(defn- retry-step?
+  "True if we should retry this step, false otherwise."
+  [options step]
+  (and (not= :pass (::step/outcome step))
+       (= (:on-fail options) :prompt)
+       (prompt-for-retry)))
+
+
 ; TODO: between steps, write out current state to a local file?
 (defn- run-steps!
   "Executes a sequence of test steps by running them in order until one fails.
   Returns a tuple with the enriched vector of steps run and the final context
   map."
-  [system ctx steps]
+  [system options ctx steps]
   (loop [history []
          ctx ctx
          steps steps]
@@ -147,7 +168,9 @@
         ; Continue while steps pass.
         (if (= :pass (::step/outcome step'))
           (recur history' ctx' (next steps))
-          [(vec (concat history' (rest steps))) ctx']))
+          (if (retry-step? options step')
+            (recur history ctx steps)
+            [(vec (concat history' (rest steps))) ctx'])))
       ; No more steps.
       [history ctx])))
 
@@ -173,12 +196,12 @@
 
 (defn run-test!
   "Execute a test. Returns the updated test map."
-  [system test-case]
+  [system options test-case]
   (*report* {:type :test-start
              :test test-case})
   (let [started-at (Instant/now)
         ctx (::context test-case {})
-        [history ctx] (run-steps! system ctx (::steps test-case))
+        [history ctx] (run-steps! system options ctx (::steps test-case))
         _ (run-cleanup! system history)
         ended-at (Instant/now)
         test-case (assoc test-case

--- a/test/greenlight/test_suite/yellow.clj
+++ b/test/greenlight/test_suite/yellow.clj
@@ -20,8 +20,7 @@
   "A step that fails until the 3rd try."
   :title "Fail Until 3rd Try"
   :test (fn [_]
-          (swap! counter inc)
-          (is (= @counter 3))))
+          (is (= 3 (swap! counter inc)))))
 
 
 (defstep error-until-3rd-try

--- a/test/greenlight/test_suite/yellow.clj
+++ b/test/greenlight/test_suite/yellow.clj
@@ -1,0 +1,45 @@
+(ns greenlight.test-suite.yellow
+  (:require
+    [clojure.test :refer [is]]
+    [com.stuartsierra.component :as component]
+    [greenlight.step :as step :refer [defstep]]
+    [greenlight.test :as test :refer [deftest]]))
+
+
+(def counter (atom 0))
+
+
+(defstep reset-counter
+  "Reset the counter."
+  :title "Reset counter"
+  :test (fn [_]
+          (reset! counter 0)))
+
+
+(defstep fail-until-3rd-try
+  "A step that fails until the 3rd try."
+  :title "Fail Until 3rd Try"
+  :test (fn [_]
+          (swap! counter inc)
+          (is (= @counter 3))))
+
+
+(defstep error-until-3rd-try
+  "A step that errors until the 3rd try."
+  :title "Error Until 3rd Try"
+  :test (fn [_]
+          (swap! counter inc)
+          (when (< @counter 3)
+            (throw (RuntimeException. "boo")))))
+
+
+(deftest fail-until-3rd-try-test
+  "A test that fails until the 3rd try"
+  (reset-counter)
+  (fail-until-3rd-try))
+
+
+(deftest error-until-3rd-try-test
+  "A test that errors until the 3rd try"
+  (reset-counter)
+  (error-until-3rd-try))

--- a/test/greenlight/test_suite/yellow.clj
+++ b/test/greenlight/test_suite/yellow.clj
@@ -27,8 +27,7 @@
   "A step that errors until the 3rd try."
   :title "Error Until 3rd Try"
   :test (fn [_]
-          (swap! counter inc)
-          (when (< @counter 3)
+          (when (< (swap! counter inc) 3)
             (throw (RuntimeException. "boo")))))
 
 

--- a/test/greenlight/test_test.clj
+++ b/test/greenlight/test_test.clj
@@ -60,8 +60,8 @@
 
 (defmacro with-io
   [input & forms]
-  `(binding [*in* (io/reader (char-array ~input))
-             *out* (io/writer (java.io.ByteArrayOutputStream.))]
+  `(binding [*in* (io/reader (java.io.StringReader. ~input))
+             *out* (io/writer (java.io.StringWriter.))]
      ~@forms))
 
 

--- a/test/greenlight/test_test.clj
+++ b/test/greenlight/test_test.clj
@@ -12,7 +12,7 @@
 (deftest sample-test
   (let [system (component/system-map :greenlight.test-test/component 6)
         sample-test (blue/sample-test)
-        test-result (test/run-test! system {} sample-test)]
+        test-result (test/run-test! system sample-test)]
     (is (= :pass (::test/outcome test-result)))
     (is (= ["Sample Step"
             "Sample Step"
@@ -24,7 +24,7 @@
 
   (let [system      (component/system-map :greenlight.test-test/component 5)
         sample-test (blue/sample-test)
-        test-result (test/run-test! system {} sample-test)]
+        test-result (test/run-test! system sample-test)]
     (is (= :fail (::test/outcome test-result)))
     (is (= ["Sample Step"
             "Sample Step"
@@ -38,7 +38,7 @@
 (deftest optional-docstring-test
   (let [system (component/system-map :greenlight.test-test/component 6)
         docstring-test (blue/optional-docstring-test)
-        test-result (test/run-test! system {} docstring-test)]
+        test-result (test/run-test! system docstring-test)]
     (is (= :pass (::test/outcome test-result)))
     (is (= ["step-1"
             "step-2"]
@@ -49,7 +49,7 @@
 (deftest optional-attr-map-test
   (let [system (component/system-map :greenlight.test-test/component 6)
         attr-test (blue/optional-attr-map)
-        test-result (test/run-test! system {} attr-test)]
+        test-result (test/run-test! system attr-test)]
     (is (= (::test/description test-result) "foobar"))
     (is (= (::test/context test-result) {:foo :bar}))
     (is (= :pass (::test/outcome test-result)))


### PR DESCRIPTION
As integration tests typically invoke big chunks of the stack, it's not
uncommon for there to be some brittleness and/or slowness in test steps.
Debugging a failure in a slow step toward the end of a slow test is just the
worst. Not only might the problem be transient, leading to slow iterations as
the entire test is rerun, but since expensive state is typically cleaned up in
cleanup handlers, the erroneous state may no longer be available for
inspection.

If only we could pause the world indefinitely when a failure happens. Now we
can with:

    (runner/run-tests! ... {:on-fail :prompt})

The prompt allows for retrying the failed step.

## Demo

greenlight:user> (run-tests)
Starting test system...
Running 1 tests...

 * Testing steps
 | user:35
 | Run the steps.
 |
 +->> user/step-1
 | 0 assertions ()
 | [PASS] (1.005 seconds)
 |
 +->> user/step-2
 | Unhandled ExecutionException: java.lang.RuntimeException: boo
 | [ERROR] (0.000 seconds)
 |
Retry? [y/n] y
 +->> user/step-2
 | Unhandled ExecutionException: java.lang.RuntimeException: boo
 | [ERROR] (0.000 seconds)
 |
Retry? [y/n] y
 +->> user/step-2
 | 0 assertions ()
 | [PASS] (1.005 seconds)
 |
 +->> user/step-3
 | 0 assertions ()
 | [PASS] (1.004 seconds)
 |
 |
 * PASS (285.288 seconds)


Ran 1 tests containing 3 steps with 0 assertions:
* 1 pass