### PR TITLE
Add report for uncaught Exception in step

### DIFF
--- a/src/greenlight/step.clj
+++ b/src/greenlight/step.clj
@@ -313,6 +313,10 @@
                               (count @reports))))
                (save-output step ctx output)])))
         (catch Exception ex
+          (ctest/do-report {:type :error
+                            :message "Uncaught exception, not in assertion."
+                            :expected nil
+                            :actual ex})
           [(output-step
              :error
              (format "Unhandled %s: %s"

--- a/src/greenlight/step.clj
+++ b/src/greenlight/step.clj
@@ -316,9 +316,8 @@
           (let [message (format "Unhandled %s: %s"
                                 (.getSimpleName (class ex))
                                 (.getMessage ex))]
-          (ctest/do-report {:type :error
-                            :message message
-                            :expected nil
-                            :actual ex})
-          [(output-step :error message)
-           ctx]))))))
+            (ctest/do-report {:type :error
+                              :message message
+                              :expected nil
+                              :actual ex})
+            [(output-step :error message) ctx]))))))

--- a/src/greenlight/step.clj
+++ b/src/greenlight/step.clj
@@ -313,13 +313,12 @@
                               (count @reports))))
                (save-output step ctx output)])))
         (catch Exception ex
+          (let [message (format "Unhandled %s: %s"
+                                (.getSimpleName (class ex))
+                                (.getMessage ex))]
           (ctest/do-report {:type :error
-                            :message "Uncaught exception, not in assertion."
+                            :message message
                             :expected nil
                             :actual ex})
-          [(output-step
-             :error
-             (format "Unhandled %s: %s"
-                     (.getSimpleName (class ex))
-                     (.getMessage ex)))
-           ctx])))))
+          [(output-step :error message)
+           ctx]))))))

--- a/test/greenlight/test_test.clj
+++ b/test/greenlight/test_test.clj
@@ -86,7 +86,7 @@
 (deftest error-report
   (let [system (component/system-map :greenlight.test-test/component 6)
         test (yellow/error-until-3rd-try-test)
-        error-result (with-io "y\nn\n" (test/run-test! system {:on-fail :prompt} test))
+        error-result (test/run-test! system {} test)
         step (-> error-result ::test/steps last)
         reports (::step/reports step)
         report (first reports)]

--- a/test/greenlight/test_test.clj
+++ b/test/greenlight/test_test.clj
@@ -82,6 +82,7 @@
     (is (= :pass (::test/outcome pass-result)))
     (is (= :error (::test/outcome error-result)))))
 
+
 (deftest error-report
   (let [system (component/system-map :greenlight.test-test/component 6)
         test (yellow/error-until-3rd-try-test)

--- a/test/greenlight/test_test.clj
+++ b/test/greenlight/test_test.clj
@@ -93,4 +93,4 @@
     (is (= 1 (count reports)))
     (is (= :error (:type report)))
     (is (instance? Exception (:actual report)))
-    (is (= (:message report) (::step/message step)))))
+    (is (= (::step/message step) (:message report)))))

--- a/test/greenlight/test_test.clj
+++ b/test/greenlight/test_test.clj
@@ -80,5 +80,16 @@
         pass-result (with-io "y\ny\n" (test/run-test! system {:on-fail :prompt} test))
         error-result (with-io "y\nn\n" (test/run-test! system {:on-fail :prompt} test))]
     (is (= :pass (::test/outcome pass-result)))
-    (is (= :error (::test/outcome error-result)))
-    (is (= :error (-> error-result ::test/steps last ::step/reports first :type)))))
+    (is (= :error (::test/outcome error-result)))))
+
+(deftest error-report
+  (let [system (component/system-map :greenlight.test-test/component 6)
+        test (yellow/error-until-3rd-try-test)
+        error-result (with-io "y\nn\n" (test/run-test! system {:on-fail :prompt} test))
+        step (-> error-result ::test/steps last)
+        reports (::step/reports step)
+        report (first reports)]
+    (is (= 1 (count reports)))
+    (is (= :error (:type report)))
+    (is (instance? Exception (:actual report)))
+    (is (= (:message report) (::step/message step)))))

--- a/test/greenlight/test_test.clj
+++ b/test/greenlight/test_test.clj
@@ -80,4 +80,5 @@
         pass-result (with-io "y\ny\n" (test/run-test! system {:on-fail :prompt} test))
         error-result (with-io "y\nn\n" (test/run-test! system {:on-fail :prompt} test))]
     (is (= :pass (::test/outcome pass-result)))
-    (is (= :error (::test/outcome error-result)))))
+    (is (= :error (::test/outcome error-result)))
+    (is (= :error (-> error-result ::test/steps last ::step/reports first :type)))))


### PR DESCRIPTION
An uncaught exception that occurs outside of an assertion in clojure.test is handled separately from exceptions that occur within an assertion. This makes sure that errors that occur outside of assertions are correctly added to the test report.

Resolves #50.