### PR TITLE
Create parent dirs to JUnit report file if needed

### DIFF
--- a/src/greenlight/report.clj
+++ b/src/greenlight/report.clj
@@ -3,6 +3,7 @@
   takes a collection of test results as input and should produce some output,
   depending on the report type."
   (:require
+    [clojure.java.io :as io]
     [clojure.spec.alpha :as s]
     [clojure.string :as str]
     [clojure.test :as ctest]
@@ -165,7 +166,9 @@
 (defn write-junit-results
   "Render a set of test results to a JUnit XML file."
   [report-path results options]
-  (spit report-path (junit/report results options)))
+  (let [report-file (io/file report-path)]
+    (.mkdirs (.getParentFile report-file))
+    (spit report-file (junit/report results options))))
 
 
 (defn write-html-results

--- a/src/greenlight/report.clj
+++ b/src/greenlight/report.clj
@@ -167,7 +167,7 @@
   "Render a set of test results to a JUnit XML file."
   [report-path results options]
   (let [report-file (io/file report-path)]
-    (.mkdirs (.getParentFile report-file))
+    (io/make-parents report-file)
     (spit report-file (junit/report results options))))
 
 


### PR DESCRIPTION
To make the JUnit reporting feature more easily useable in CI workflows, I propose automatically creating parent directories of the JUnit report file if needed. This allows CircleCI config like the following:

```yaml
- run: lein run -m my.main.greenlight.ns --junit-report build/junit.xml
- store_test_results:
    path: build
```

This change also makes Greenlight's JUnit reporter more consistent with other JUnit reporters like [kaocha](https://github.com/lambdaisland/kaocha-junit-xml/blob/main/src/kaocha/plugin/junit_xml.clj#L140) and [test2junit](https://github.com/ruedigergad/test2junit/blob/master/src/test2junit/core.clj#L43).