### PR TITLE
Improve exception reporting

### DIFF
--- a/.cljstyle
+++ b/.cljstyle
@@ -1,0 +1,4 @@
+{:rules
+ {:indentation
+  {:indents
+   {defstep [[:block 1]]}}}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Changed
+- When an unhandled exception is thrown in a test, report the
+  exception that was thrown in the test instead of reporting an
+  ExecutionException that was thrown in greenlight code. [#59](https://github.com/amperity/greenlight/pull/59)
+- Use [org.clj-commons/pretty](https://github.com/clj-commons/pretty) for pretty
+  formatting of exceptions. [#59](https://github.com/amperity/greenlight/pull/59)
 - Update Clojure to 1.11.1. [#60](https://github.com/amperity/greenlight/pull/60)
 
 ### Fixed

--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,8 @@
    [org.clojure/tools.cli "1.0.194"]
    [org.clojure/data.xml "0.0.8"]
    [amperity/envoy "0.3.3"]
-   [com.stuartsierra/component "1.0.0"]]
+   [com.stuartsierra/component "1.0.0"]
+   [org.clj-commons/pretty "2.1"]]
 
   :codox
   {:metadata {:doc/format :markdown}

--- a/src/greenlight/runner.clj
+++ b/src/greenlight/runner.clj
@@ -2,6 +2,7 @@
   "Entry point for running a suite of tests and generating reports from the
   results."
   (:require
+    [clj-commons.pretty.repl :as pretty.repl]
     [clojure.set :as set]
     [clojure.spec.alpha :as s]
     [clojure.string :as str]
@@ -266,6 +267,7 @@
   [new-system tests args]
   (let [{:keys [options arguments summary errors]} (cli/parse-opts args cli-options)
         command (or (first arguments) "test")]
+    (pretty.repl/install-pretty-exceptions)
     (cond
       errors
       (*exit* 1 (str/join "\n" errors))

--- a/src/greenlight/step.clj
+++ b/src/greenlight/step.clj
@@ -4,7 +4,9 @@
     [clojure.spec.alpha :as s]
     [clojure.string :as str]
     [clojure.test :as ctest]
-    [greenlight.assert :as assert]))
+    [greenlight.assert :as assert])
+  (:import
+    java.util.concurrent.ExecutionException))
 
 
 ;; ## Step Configuration
@@ -299,38 +301,48 @@
                             ::reports @reports)]
     (binding [ctest/report (partial swap! reports conj)
               *pending-cleanups* (atom [])]
-      (try
-        (let [test-fn (::test step)
-              timeout (::timeout step 60)
-              inputs (collect-inputs system ctx step)
-              step-future (future (test-fn inputs))
-              output (deref step-future (* 1000 timeout) ::timeout)]
-          (if (= output ::timeout)
-            (do
-              (future-cancel step-future)
-              [(output-step
-                 :timeout
-                 (format "Step timed out after %d seconds" timeout))
-               ctx])
-            (let [report-types (group-by assert/report->outcome @reports)
-                  passed? (and (empty? (::assert/fail report-types))
-                               (empty? (::assert/error report-types)))]
-              [(output-step
-                 (if passed? :pass :fail)
-                 (->> report-types
-                      (map #(format "%d %s"
-                                    (count (val %))
-                                    (name (key %))))
-                      (str/join ", ")
-                      (format "%d assertions (%s)"
-                              (count @reports))))
-               (save-output step ctx output)])))
-        (catch Exception ex
-          (let [message (format "Unhandled %s: %s"
-                                (.getSimpleName (class ex))
-                                (.getMessage ex))]
+      (let [test-fn (::test step)
+            timeout (::timeout step 60)
+            inputs (collect-inputs system ctx step)
+            step-future (future (test-fn inputs))
+            result (try
+                     (deref step-future (* 1000 timeout) ::timeout)
+                     (catch ExecutionException ex
+                       (ex-cause ex)))]
+        (cond
+          (= result ::timeout)
+          (do
+            (future-cancel step-future)
+            [(output-step
+               :timeout
+               (format "Step timed out after %d seconds" timeout))
+             ctx])
+
+          (instance? Throwable result)
+          (let [ex ^Throwable result
+                message (str "Unhandled "
+                             (.getName (class ex))
+                             ": "
+                             (ex-message ex)
+                             (when-let [data (ex-data ex)]
+                               (str " " (pr-str data))))]
             (ctest/do-report {:type :error
                               :message message
                               :expected nil
                               :actual ex})
-            [(output-step :error message) ctx]))))))
+            [(output-step :error message) ctx])
+
+          :else
+          (let [report-types (group-by assert/report->outcome @reports)
+                passed? (and (empty? (::assert/fail report-types))
+                             (empty? (::assert/error report-types)))]
+            [(output-step
+               (if passed? :pass :fail)
+               (->> report-types
+                    (map #(format "%d %s"
+                                  (count (val %))
+                                  (name (key %))))
+                    (str/join ", ")
+                    (format "%d assertions (%s)"
+                            (count @reports))))
+             (save-output step ctx result)]))))))

--- a/src/greenlight/step.clj
+++ b/src/greenlight/step.clj
@@ -307,8 +307,14 @@
             step-future (future (test-fn inputs))
             result (try
                      (deref step-future (* 1000 timeout) ::timeout)
+                     ;; If deref throws an ExecutionException, it means user
+                     ;; code in the step threw an exception and greenlight should
+                     ;; report the exception in user code, which is the cause.
                      (catch ExecutionException ex
-                       (ex-cause ex)))]
+                       (ex-cause ex))
+                     ;; Otherwise, exceptions can be reported as-is.
+                     (catch Exception ex
+                       ex))]
         (cond
           (= result ::timeout)
           (do


### PR DESCRIPTION
## Description

#58 Currently greenlight executes all test steps inside a future and derefs that future with a timeout. If the step throws an exception, the deref throws an ExecutionException with the original exception as the cause. Greenlight currently reports the ExecutionException thrown by deref, instead of the exception that was thrown in the test. This resolves #58 by reporting the cause of the ExecutionException instead.

Also seized the opportunity to improve the formatting of exception output in greenlight by including https://github.com/clj-commons/pretty. I can remove this if reviewers object (it can be included by consumers of greenlight instead if that feels cleaner).

### Current output on main

```
Starting test system...
Running 1 tests...

 * Testing example-test
 | amperity.user.main:15
 | Example test
 |
 +->> Example

ERROR in () (FutureTask.java:122)
Unhandled ExecutionException: clojure.lang.ExceptionInfo: ouch {:type "asd"}
expected: nil
  actual: java.util.concurrent.ExecutionException: clojure.lang.ExceptionInfo: ouch {:type "asd"}
 at java.util.concurrent.FutureTask.report (FutureTask.java:122)
    java.util.concurrent.FutureTask.get (FutureTask.java:205)
    clojure.core$deref_future.invokeStatic (core.clj:2302)
    clojure.core$future_call$reify__8454.deref (core.clj:6974)
    clojure.core$deref.invokeStatic (core.clj:2324)
    clojure.core$deref.invoke (core.clj:2306)
    greenlight.step$advance_BANG_.invokeStatic (step.clj:307)
    greenlight.step$advance_BANG_.invoke (step.clj:287)
    greenlight.test$run_steps_BANG_.invokeStatic (test.clj:174)
    greenlight.test$run_steps_BANG_.invoke (test.clj:161)
    greenlight.test$run_test_BANG_.invokeStatic (test.clj:216)
    greenlight.test$run_test_BANG_.invoke (test.clj:207)
    clojure.core$partial$fn__5841.invoke (core.clj:2631)
    clojure.core$mapv$fn__8445.invoke (core.clj:6912)
    clojure.lang.PersistentVector.reduce (PersistentVector.java:343)
    clojure.core$reduce.invokeStatic (core.clj:6827)
    clojure.core$mapv.invokeStatic (core.clj:6903)
    clojure.core$mapv.invoke (core.clj:6903)
    greenlight.runner$run_tests_BANG_.invokeStatic (runner.clj:208)
    greenlight.runner$run_tests_BANG_.invoke (runner.clj:190)
    greenlight.runner$main.invokeStatic (runner.clj:295)
    greenlight.runner$main.invoke (runner.clj:263)
    amperity.user.main$_main.invokeStatic (main.clj:22)
    amperity.user.main$_main.doInvoke (main.clj:20)
    clojure.lang.RestFn.invoke (RestFn.java:397)
    clojure.lang.Var.invoke (Var.java:380)
    user$eval140.invokeStatic (form-init10091052269480591438.clj:1)
    user$eval140.invoke (form-init10091052269480591438.clj:1)
    clojure.lang.Compiler.eval (Compiler.java:7177)
    clojure.lang.Compiler.eval (Compiler.java:7167)
    clojure.lang.Compiler.load (Compiler.java:7636)
    clojure.lang.Compiler.loadFile (Compiler.java:7574)
    clojure.main$load_script.invokeStatic (main.clj:475)
    clojure.main$init_opt.invokeStatic (main.clj:477)
    clojure.main$init_opt.invoke (main.clj:477)
    clojure.main$initialize.invokeStatic (main.clj:508)
    clojure.main$null_opt.invokeStatic (main.clj:542)
    clojure.main$null_opt.invoke (main.clj:539)
    clojure.main$main.invokeStatic (main.clj:664)
    clojure.main$main.doInvoke (main.clj:616)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.lang.Var.applyTo (Var.java:705)
    clojure.main.main (main.java:40)
Caused by: clojure.lang.ExceptionInfo: ouch
{:type "asd"}
 at amperity.user.main$example_step$fn__1830.invoke (main.clj:12)
    greenlight.step$advance_BANG_$fn__1524.invoke (step.clj:306)
    clojure.core$binding_conveyor_fn$fn__5754.invoke (core.clj:2030)
    clojure.lang.AFn.call (AFn.java:18)
    java.util.concurrent.FutureTask.run (FutureTask.java:264)
    java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1128)
    java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:628)
    java.lang.Thread.run (Thread.java:829)
 | Unhandled ExecutionException: clojure.lang.ExceptionInfo: ouch {:type "asd"}
 | [ERROR] (0.006 seconds)
 |
 |
 * ERROR (0.013 seconds)


Ran 1 tests containing 1 steps with 1 assertions:
* 1 error
```

### New output on this branch

```
Starting test system...
Running 1 tests...

 * Testing example-test
 | amperity.user.main:15
 | Example test
 |
 +->> Example

ERROR in () (main.clj:12)
Unhandled clojure.lang.ExceptionInfo: ouch {:type "asd"}
expected: nil
  actual:
                              java.lang.Thread.run              Thread.java:  829
java.util.concurrent.ThreadPoolExecutor$Worker.run  ThreadPoolExecutor.java:  628
 java.util.concurrent.ThreadPoolExecutor.runWorker  ThreadPoolExecutor.java: 1128
               java.util.concurrent.FutureTask.run          FutureTask.java:  264
                                               ...
               clojure.core/binding-conveyor-fn/fn                 core.clj: 2030
                       greenlight.step/advance!/fn                 step.clj:  307
                amperity.user.main/example-step/fn                 main.clj:   12
clojure.lang.ExceptionInfo: ouch
    type: "asd"

 | Unhandled clojure.lang.ExceptionInfo: ouch {:type "asd"}
 | [ERROR] (0.006 seconds)
 |
 |
 * ERROR (0.017 seconds)


Ran 1 tests containing 1 steps with 1 assertions:
* 1 error
```