### PR TITLE
Get CI passing again, version bumps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,9 +26,6 @@ jobs:
       - store_artifacts:
           path: target/coverage
           destination: coverage
-      - run:
-          name: Publish Coverage
-          command: "(curl -s https://codecov.io/bash > codecov) && bash codecov -f target/coverage/codecov.json"
   style:
     executor: clojure
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
       - run:
           name: Install cljstyle
           environment:
-            CLJSTYLE_VERSION: 0.12.1
+            CLJSTYLE_VERSION: 0.15.0
           command: |
             wget https://github.com/greglook/cljstyle/releases/download/${CLJSTYLE_VERSION}/cljstyle_${CLJSTYLE_VERSION}_linux.tar.gz
             tar -xzf cljstyle_${CLJSTYLE_VERSION}_linux.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- Update Clojure to 1.11.1. [#60](https://github.com/amperity/greenlight/pull/60)
+
+### Fixed
+- Fix a call to `clojure.core/format` with an invalid format string. [#60](https://github.com/amperity/greenlight/pull/60)
+
 
 ## [0.6.1] - 2021-06-11
 
@@ -104,7 +110,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 Initial project release
 
 
-[Unreleased]: https://github.com/amperity/greenlight/compare/0.4.0...HEAD
+[Unreleased]: https://github.com/amperity/greenlight/compare/0.6.1...HEAD
+[0.6.1]: https://github.com/amperity/greenlight/compare/0.6.0...0.6.1
+[0.6.0]: https://github.com/amperity/greenlight/compare/0.5.0...0.6.0
+[0.5.0]: https://github.com/amperity/greenlight/compare/0.4.0...0.5.0
 [0.4.0]: https://github.com/amperity/greenlight/compare/0.3.0...0.4.0
 [0.3.0]: https://github.com/amperity/greenlight/compare/0.2.0...0.3.0
 [0.2.0]: https://github.com/amperity/greenlight/compare/0.1.7...0.2.0

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@ Greenlight
 ==========
 
 [![CircleCI](https://circleci.com/gh/amperity/greenlight.svg?style=shield&circle-token=6db00254bc95e32ec743f6e7e7e812c05f436f88)](https://circleci.com/gh/amperity/greenlight)
-[![codecov](https://codecov.io/gh/amperity/greenlight/branch/master/graph/badge.svg)](https://codecov.io/gh/amperity/greenlight)
 
 This library provides an _integration testing_ framework for Clojure. Running
 a suite of tests against your systems gives you the confidence to _greenlight_

--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
   :pedantic? :abort
 
   :dependencies
-  [[org.clojure/clojure "1.10.1"]
+  [[org.clojure/clojure "1.11.1"]
    [org.clojure/tools.cli "1.0.194"]
    [org.clojure/data.xml "0.0.8"]
    [amperity/envoy "0.3.3"]

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
   :aliases
   {"coverage" ["with-profile" "+test,+coverage" "cloverage"]}
 
-  :pedantic? :abort
+  :pedantic? :warn
 
   :dependencies
   [[org.clojure/clojure "1.11.1"]

--- a/src/greenlight/report.clj
+++ b/src/greenlight/report.clj
@@ -174,5 +174,5 @@
 (defn write-html-results
   "Render a set of test results to a human-friendly HTML file."
   [report-path results options]
-  ; TODO: implement html reporting (#7)
+  ;; TODO: implement html reporting (#7)
   (println "WARN: HTML reporting is not available yet"))

--- a/src/greenlight/runner.clj
+++ b/src/greenlight/runner.clj
@@ -211,10 +211,10 @@
              (report-results results options)
              (when-let [result-path (:output options)]
                (println "Saving test results to" result-path)
-               ; FIXME: this results in unreadable data because it often includes
-               ; exceptions in the assertion reports.
+               ;; FIXME: this results in unreadable data because it often includes
+               ;; exceptions in the assertion reports.
                (spit result-path (prn-str results)))
-             ; Successful if every test passed.
+             ;; Successful if every test passed.
              (every? (comp #{:pass} ::test/outcome) results)))
          (finally
            (stop-system system)))))))
@@ -231,7 +231,7 @@
   [new-system options result-files]
   (prn options)
   (prn result-files)
-  ; TODO: load and clean results (#4)
+  ;; TODO: load and clean results (#4)
   (throw (RuntimeException. "NYI")))
 
 
@@ -240,7 +240,7 @@
   [options result-files]
   (prn options)
   (prn result-files)
-  ; TODO: load and report results (#5)
+  ;; TODO: load and report results (#5)
   (throw (RuntimeException. "NYI")))
 
 

--- a/src/greenlight/step.clj
+++ b/src/greenlight/step.clj
@@ -12,12 +12,14 @@
 ;; Step name symbol.
 (s/def ::name symbol?)
 
+
 ;; Human friendly title string for the step.
 ;; Can be supplied as a string or a function of the test context
 ;; that returns a string.
 (s/def ::title
   (s/or :str string?
         :fn fn?))
+
 
 ;; Used for context lookups. Can be a keyword for direct access,
 ;; a collection of values for `get-in`, or a function of the context.
@@ -26,9 +28,11 @@
         :kws (s/coll-of any? :min-count 1 :kind sequential?)
         :fn fn?))
 
+
 ;; System component keyword
 (s/def ::component
   keyword?)
+
 
 ;; Map of inputs for test function. Value can be
 ;; a value, component or context key.
@@ -38,6 +42,7 @@
                   :component (s/keys :req [::component])
                   :value any?)))
 
+
 ;; Output result to store in step context. Can be a keyword,
 ;; a collection of values as keys, or a function (ctx, return-value) -> ctx'
 (s/def ::output
@@ -45,13 +50,16 @@
         :kws (s/coll-of any? :min-count 1 :kind sequential?)
         :fn fn?))
 
+
 ;; The timeout defines the maximum amount of time that the step will be allowed
 ;; to run, in seconds. Steps which exceed this will fail the test.
 (s/def ::timeout pos-int?)
 
+
 ;; Function which will be invoked with the step configuration, selected
 ;; components, and current test context in order to execute the test logic.
 (s/def ::test fn?)
+
 
 ;; The configuration map ultimately drives the execution of each step. This map
 ;; is built when tests are initialized and immutable afterwards.
@@ -127,20 +135,25 @@
 ;; - `:timeout` if the step ran longer than the allowed duration.
 (s/def ::outcome #{:pass :fail :error :timeout})
 
+
 ;; A message to the user about why the step has its current state. May include
 ;; remediation steps or areas to look at fixing.
 (s/def ::message string?)
 
+
 ;; Sequence of cleanup actions to take.
 (s/def ::cleanup (s/coll-of any? :kind vector?))
+
 
 ;; Duration in seconds that the step ran for.
 (s/def ::elapsed float?)
 
+
 ;; Collection of reported clojure.test assertions.
 (s/def ::reports (s/coll-of map? :kind vector?))
 
-; TODO: capture stdout/stderr/logs?
+
+;; TODO: capture stdout/stderr/logs?
 
 ;; Aggregate result fields.
 (s/def ::results

--- a/src/greenlight/step.clj
+++ b/src/greenlight/step.clj
@@ -184,14 +184,14 @@
   "Multimethod to clean up a created resource after a test finishes. Given the
   entire system to choose dependencies from."
   (fn dispatch
-    [system resource-type parameters]
+    [_system resource-type _parameters]
     resource-type))
 
 
 (defmethod clean! :default
-  [system resource-type parameters]
+  [_system resource-type parameters]
   (throw (RuntimeException.
-           (format "Don't know how to clean up resource"
+           (format "Don't know how to clean up resource type %s with parameters %s"
                    resource-type
                    (pr-str parameters)))))
 

--- a/src/greenlight/test.clj
+++ b/src/greenlight/test.clj
@@ -15,18 +15,23 @@
 ;; Namespace where the test is defined.
 (s/def ::ns symbol?)
 
+
 ;; Source line where the test is defined.
 (s/def ::line integer?)
+
 
 ;; Title of the test run.
 (s/def ::title string?)
 
+
 ;; Human-friendly description of the scenario the test covers.
 (s/def ::description string?)
+
 
 ;; Test execution group tag. Tests within the same group
 ;; are executed in serial.
 (s/def ::group keyword?)
+
 
 ;; Sequence of steps to take for this test.
 (s/def ::steps
@@ -34,8 +39,10 @@
              :kind vector?
              :min-count 1))
 
+
 ;; Initial and final context map for the test.
 (s/def ::context map?)
+
 
 ;; The test case map defines metadata about the test and its steps.
 (s/def ::case
@@ -45,6 +52,7 @@
                 ::line
                 ::description
                 ::context]))
+
 
 ;; Collection of test cases.
 (s/def ::suite
@@ -99,8 +107,10 @@
 ;; Final outcome of the test case.
 (s/def ::outcome ::step/outcome)
 
+
 ;; When the test run started.
 (s/def ::started-at inst?)
+
 
 ;; When the test run ended.
 (s/def ::ended-at inst?)
@@ -123,7 +133,7 @@
   "Dynamic reporting function which is called at various points in the test
   execution. The event data should be a map containing at least a `:type` key."
   [event]
-  ; Default no-op action.
+  ;; Default no-op action.
   nil)
 
 
@@ -147,7 +157,7 @@
        (prompt-for-retry)))
 
 
-; TODO: between steps, write out current state to a local file?
+;; TODO: between steps, write out current state to a local file?
 (defn- run-steps!
   "Executes a sequence of test steps by running them in order until one fails.
   Returns a tuple with the enriched vector of steps run and the final context
@@ -157,7 +167,7 @@
          ctx ctx
          steps steps]
     (if-let [step (first steps)]
-      ; Run next step to advance the test.
+      ;; Run next step to advance the test.
       (let [step (step/initialize step ctx)
             _ (*report* {:type :step-start
                          :step step})
@@ -165,13 +175,13 @@
             history' (conj history step')]
         (*report* {:type :step-end
                    :step step'})
-        ; Continue while steps pass.
+        ;; Continue while steps pass.
         (if (= :pass (::step/outcome step'))
           (recur history' ctx' (next steps))
           (if (retry-step? options step')
             (recur history ctx steps)
             [(vec (concat history' (rest steps))) ctx'])))
-      ; No more steps.
+      ;; No more steps.
       [history ctx])))
 
 


### PR DESCRIPTION
* Bump to Clojure 1.11.1
* Use cljstyle 1.15.0 in CI and apply `cljstyle fix`
* Fix format string bug found by clj-kondo linting
* Relax dependency pedantry since this was failing the `lein coverage` command in CI
* Disable publishing code coverage results to codecov for now