### PR TITLE
Fix a bug where a step that _returns_ an exception object is reported…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-...
+
+### Fixed
+- Fix a bug introduced in 0.7.0 where _returning_ an exception from a step causes
+  the step to fail and be reported as having thrown an unhandled exception.
+  [#64](https://github.com/amperity/greenlight/pull/64)
 
 ## [0.7.0] - 2023-08-17
 

--- a/test/greenlight/test_test.clj
+++ b/test/greenlight/test_test.clj
@@ -121,15 +121,15 @@
 
 
 (step/defstep step-that-returns-an-exception
-  "A step that throws an exception."
-  :title "Throw an exception."
+  "A step that returns an exception object."
+  :title "Return an exception object."
   :test (fn [_]
           (is (thrown? Exception
                 (throw (Exception.))))))
 
 
 (test/deftest test-with-a-step-that-returns-an-exception
-  "A test that throws an exception."
+  "A test with a step that returns an exception object."
   (step-that-returns-an-exception))
 
 

--- a/test/greenlight/test_test.clj
+++ b/test/greenlight/test_test.clj
@@ -100,21 +100,39 @@
   (ex-info "ouch" {:some "data"}))
 
 
-(step/defstep step-that-throws
+(step/defstep step-that-throws-an-unhandled-exception
   "A step that throws an exception."
   :title "Throw an exception."
   :test (fn [_]
           (throw mock-exception)))
 
 
-(test/deftest test-that-throws
+(test/deftest test-that-throws-an-unhandled-exception
   "A test that throws an exception."
-  (step-that-throws))
+  (step-that-throws-an-unhandled-exception))
 
 
-(deftest exception-in-step
-  (let [result (test/run-test! {} {} (test-that-throws))
+(deftest test-throws-an-unhandled-exception
+  (let [result (test/run-test! {} {} (test-that-throws-an-unhandled-exception))
         step (-> result ::test/steps last)
         report (first (::step/reports step))]
     (is (= :error (:type report)))
     (is (identical? mock-exception (:actual report)))))
+
+
+(step/defstep step-that-returns-an-exception
+  "A step that throws an exception."
+  :title "Throw an exception."
+  :test (fn [_]
+          (is (thrown? Exception
+                (throw (Exception.))))))
+
+
+(test/deftest test-with-a-step-that-returns-an-exception
+  "A test that throws an exception."
+  (step-that-returns-an-exception))
+
+
+(deftest test-returns-an-exception
+  (let [result (test/run-test! {} {} (test-with-a-step-that-returns-an-exception))]
+    (is (= :pass (::test/outcome result)))))


### PR DESCRIPTION
… as having thrown an unhandled exception.

PR #59 introduced a bug where a step that _returns_ an exception object fails. An example of this is a test function whose last expresssion is an assertion that something is thrown:
```
(is (thrown? Exception ,,,))
```

Fixed by distinguishing thrown vs. returned exceptions and adding unit tests.