### PR TITLE
Catch exceptions in greenlight's main function and exit after

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-...
+
+### Changed
+- When an unhandled exception is thrown by the test runner, the main
+  function will print the stacktraces for the exception and properly exit.
+  This is to avoid the edge case where a thread started by the test system
+  can cause the JVM to indefinitely hang instead of exiting.
 
 ## [0.7.1] - 2023-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   function will print the stacktraces for the exception and properly exit.
   This is to avoid the edge case where a thread started by the test system
   can cause the JVM to indefinitely hang instead of exiting.
+  [#66](https://github.com/amperity/greenlight/pull/66)
 
 ## [0.7.1] - 2023-08-22
 

--- a/src/greenlight/runner.clj
+++ b/src/greenlight/runner.clj
@@ -5,6 +5,7 @@
     [clj-commons.pretty.repl :as pretty.repl]
     [clojure.set :as set]
     [clojure.spec.alpha :as s]
+    [clojure.stacktrace :as stacktrace]
     [clojure.string :as str]
     [clojure.test :as ctest]
     [clojure.tools.cli :as cli]
@@ -294,7 +295,14 @@
       (->
         (case command
           "info" (print-test-info tests options (rest arguments))
-          "test" (run-tests! new-system tests options (rest arguments))
+          "test" (try
+                   (run-tests! new-system tests options (rest arguments))
+                   (catch Exception ex
+                     (println "Uncaught exception in test runner:")
+                     (stacktrace/print-stack-trace ex)
+                     (println "Caused by:")
+                     (stacktrace/print-cause-trace ex)
+                     (*exit* 1)))
           "clean" (clean-results! new-system options (rest arguments))
           "report" (generate-report options (rest arguments))
           (*exit* 1 (str "The argument " (pr-str command) " is not a supported command")))

--- a/src/greenlight/runner.clj
+++ b/src/greenlight/runner.clj
@@ -299,8 +299,6 @@
                    (run-tests! new-system tests options (rest arguments))
                    (catch Exception ex
                      (println "Uncaught exception in test runner:")
-                     (stacktrace/print-stack-trace ex)
-                     (println "Caused by:")
                      (stacktrace/print-cause-trace ex)
                      (*exit* 1)))
           "clean" (clean-results! new-system options (rest arguments))


### PR DESCRIPTION
We've seen some instances where an exception in the test runner can cause the JVM to hang indefinitely, such as when the test config is invalid but the test system has some threads still running.

Let's try wrapping our test runner with a try/catch, and logging any exceptions that come up and explicitly exit afterward.

Tested this by throwing an exception in main while having a thread running in the background, and verified that I could reproduce the JVM hanging and that this PR addresses that issue.

#nsq i noticed this project isn't really using `clojure.tools.logging` at all, is that a hard rule? it's technically already being pulled in as a dependency from `amperity/envoy`